### PR TITLE
GDP source/sink gateways + image writing utility

### DIFF
--- a/rosgdp/README.md
+++ b/rosgdp/README.md
@@ -1,0 +1,9 @@
+# ROS gateway [Work in progress]
+
+A minimalistic GDP gateway for ROS.
+
+- `gdp_sink.py`: A ROS node that listens to specified topics and logs them to a
+  specified GDP log.
+- `gdp_source.py`: A ROS node that subscribes to a given GDP log and publishes
+  the contents to appropriate ROS topics.
+

--- a/rosgdp/capture_img.py
+++ b/rosgdp/capture_img.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+
+import cv2
+import rospy
+import sys
+import time
+import argparse
+from cv_bridge import CvBridge, CvBridgeError
+from sensor_msgs.msg import Image
+
+
+def _parse_args():
+    """returns arguments passed to this node"""
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("type", choices=["color", "depth"],
+                        help="Type of image to capture")
+    parser.add_argument("path", type=str,
+                        help="Path where the images ought to be stored, "
+                             "the images are named as path-timestamp.png")
+    parser.add_argument("-t", "--topic", type=str,
+                        help="override default topics for image source")
+    parser.add_argument("-p", "--prefix", type=str, default="",
+                        help="simply add a prefix to the topic name. "
+                             "Don't use it together with --topic")
+
+    # cleaned up arguments 
+    _args = rospy.myargv(argv=sys.argv)[1:]
+    return parser.parse_args(args=_args)
+
+
+def cb(data, (pre, enc)):
+    try:
+        bridge = CvBridge()
+        img = bridge.imgmsg_to_cv2(data, desired_encoding=enc)
+        path = "%s-%s.png" % (pre, str(time.time()))
+        print "Writing image to %s" % path
+        cv2.imwrite(path, img)
+
+    except CvBridgeError as e:
+        print e
+
+
+def init():
+
+    rospy.init_node("capture_image", anonymous=True)
+    args = _parse_args()
+
+    if args.type == "color":
+        topic = args.prefix + "/hsrb/head_rgbd_sensor/rgb/image_rect_color"
+        encoding = "bgr8"
+    else:
+        topic = args.prefix + "/hsrb/head_rgbd_sensor/depth_registered/image_rect_raw"
+        encoding = "passthrough"
+
+    if args.topic is not None:
+        topic = args.topic
+    
+    subscriber = rospy.Subscriber(topic, Image, cb,
+                            callback_args=(args.path, encoding))
+    rospy.spin()
+
+if __name__=="__main__":
+    init()

--- a/rosgdp/gdp_sink.py
+++ b/rosgdp/gdp_sink.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+
+import rospy
+import rostopic
+import gdp
+import sys
+import pickle
+import zlib
+import argparse
+from threading import Lock
+from rospy.msg import AnyMsg
+
+## Let's start with a single-writer mode, logging to a single log
+## that has been created in advance.
+
+## We log a hardcoded list of topics to a single log. We note the name
+## of the topic along with the message. For large messages, we need to
+## split the message into multiple records.
+
+MAX_RECSIZE = 60000
+
+def callback(msg, (topic, lh, lck)):
+    """Callback that serializes the message and logs to GDP"""
+
+    with lck: # Locking is necessary to ensure no interleaving.
+
+        print "Received message"
+        buf = zlib.compress(pickle.dumps(msg))
+
+        # Since we will soon have an upper limit on the size of
+        # individual GDP records, we split large messages into
+        # a sequence of records. The actual data that gets written
+        # to a GDP log is a JSON dictionary that looks roughly like:
+        # {topic: <>, msg_size: <>, offset: <>. data: <>}
+
+        num_chunks = 1 + len(buf)/MAX_RECSIZE
+        d = {}
+        d["topic"] = topic
+        _full_topic = rospy.names.resolve_name(topic)
+        d["topic_type"] = rostopic.get_topic_type(_full_topic)[0]
+        d["msg_size"] = len(buf)
+    
+        for i in xrange(0, len(buf), MAX_RECSIZE):
+            d["offset"] = i
+            d["data"] = buf[i:i+MAX_RECSIZE]
+            serialized = pickle.dumps(d)
+            lh.append({'data': serialized})
+
+def _parse_args():
+    """returns arguments passed to this node"""
+
+    # setup argument parsing. These could be either passed on
+    # command line (when invoking directly), or via a .launch file
+    # when using roslaunch
+    parser = argparse.ArgumentParser()
+    parser.add_argument("logname", type=str, help="GDP log")
+    parser.add_argument("-t", "--topic", action="append",
+                            help="ROS topics to listen to (one or more).",
+                            required=True)
+
+    # cleaned up arguments 
+    _args = rospy.myargv(argv=sys.argv)[1:]
+    return parser.parse_args(args=_args)
+
+def gdp_sink():
+
+    rospy.init_node("gdp_sink")
+    gdp.gdp_init()
+    lock = Lock()
+    args = _parse_args()
+
+    gcl_name = gdp.GDP_NAME(args.logname)
+    lh = gdp.GDP_GCL(gcl_name, gdp.GDP_MODE_RA)
+
+    for t in args.topic:
+        rospy.Subscriber(t, AnyMsg, callback, callback_args=(t, lh, lock))
+
+    rospy.spin()
+
+if __name__=="__main__":
+    gdp_sink()

--- a/rosgdp/gdp_source.py
+++ b/rosgdp/gdp_source.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+
+import rospy
+import roslib
+import rostopic
+import gdp
+import pickle
+import zlib
+import sys
+import argparse
+from threading import Lock
+from std_msgs.msg import String, Float64
+from rospy.msg import AnyMsg
+
+def _parse_args():
+    """returns arguments passed to this node"""
+
+    # setup argument parsing. These could be either passed on
+    # command line (when invoking directly), or via a .launch file
+    # when using roslaunch
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--preserve", action="store_true", help="Preserve "
+                            "the topic names as is. Default False")
+    parser.add_argument("logname", type=str, help="GDP log")
+
+    # cleaned up arguments 
+    _args = rospy.myargv(argv=sys.argv)[1:]
+    return parser.parse_args(args=_args)
+
+
+def gdp_source():
+
+    rospy.init_node("gdp_source")
+    gdp.gdp_init()
+    lock = Lock()
+    args = _parse_args()
+
+    topic_dict = {}
+
+    gcl_name = gdp.GDP_NAME(args.logname)
+    loghandle = gdp.GDP_GCL(gcl_name, gdp.GDP_MODE_RO)
+    loghandle.subscribe(0, 0, None)
+
+    try:
+        buf = ""
+        while not rospy.is_shutdown():
+
+            event = loghandle.get_next_event(None)
+            data = event["datum"]["data"]
+            d = pickle.loads(data)
+            if args.preserve:
+                topic = d["topic"]
+            else:
+                topic = "/gdp" + rospy.names.resolve_name(d["topic"])
+            topic_type = d["topic_type"]
+
+            try:
+                assert len(buf) == d["offset"]
+            except AssertionError:
+                ## This is when we start at the wrong time, and some
+                ## chunks of a message already have been missed.
+                continue
+
+            buf = buf + d["data"]
+
+            if len(buf) == d["msg_size"]:
+                with lock: ## get publisher, create if doesn't exist
+                    pub = topic_dict.get(topic, None)
+                    if pub is None:
+                        msg_class = roslib.message.get_message_class(topic_type)
+                        pub = rospy.Publisher(topic, msg_class, queue_size=10)
+                        topic_dict[topic] = pub 
+
+                print "Publishing message"
+                pub.publish(pickle.loads(zlib.decompress(buf)))
+                buf = ""
+
+    except rospy.ROSInterruptException:
+        pass
+
+    del loghandle
+
+if __name__=="__main__":
+    gdp_source()


### PR DESCRIPTION
Still a work in progress, but allows one to subscribe to arbitrary topics from one ros network, and publish received messages in real time (or potentially at a later time) again, either to the same ros network under a different name, or to a different ros network elsewhere.

Also included is a standalone utility (without needing to startup a full robot interface) that can dump images directly from the corresponding topics `/hsrb/head_rgbd_sensor/rgb/image_rect_color` and `/hsrb/head_rgbd_sensor/depth_registered/image_rect_raw` for color images and depth images. (Depth images not tested yet)